### PR TITLE
fix: corrected typo on scss import path

### DIFF
--- a/src/scripts/HelloForm.js
+++ b/src/scripts/HelloForm.js
@@ -1,6 +1,6 @@
 import HelloSayer from './HelloSayer';
 import React from 'react';
-import style from '../styles/Helloform.scss';
+import style from '../styles/helloform.scss';
 
 class HelloForm extends React.Component {
     constructor(props) {


### PR DESCRIPTION
FIxed typo on SCSS import in `src/scripts/HelloForm.js`

`ERROR in ./src/scripts/HelloForm.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../styles/Helloform.scss in /home/projects/react-webpack-babel-kit/src/scripts
 @ ./src/scripts/HelloForm.js 17:17-52
webpack: Failed to compile.`