### PR TITLE
Add uglifyjs-webpack-plugin as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-hot-loader": "3.0.0-beta.7",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
+    "uglifyjs-webpack-plugin": "^0.4.6",
     "url-loader": "0.5.8",
     "webpack": "2.6.1",
     "webpack-dev-server": "2.4.5"


### PR DESCRIPTION
I tried to run npm run build but it threw an error because uglifyjs could not be found.  I added uglifyjs-webpack-plugin as a dev dependency, ran npm install and then npm run build was able to run successfully. Thank you for all your hard work on this repo, I hope this contribution can help. 